### PR TITLE
fix(google-oauth): family_name is nullable

### DIFF
--- a/src/apps/oauth/models/domain/google.py
+++ b/src/apps/oauth/models/domain/google.py
@@ -2,13 +2,19 @@
 https://accounts.google.com/.well-known/openid-configuration
 """
 
+from typing import Optional
+
 from pydantic import BaseModel, Field
 
 from ....users.models.domain import UserInfo
 
 
 class GoogleUserInfo(UserInfo):
-    family_name: str = Field(..., description="성")
+    """ 구글 유저 정보
+    family_name이 없는 나라도 있음
+    """
+
+    family_name: Optional[str] = Field(default="", description="성")
     given_name: str = Field(..., description="이름")
     email_verified: bool = Field(..., description="이메일 인증 여부")
     locale: str = Field(..., description="국가")


### PR DESCRIPTION
### [1.14.2](https://github.com/Nexters/landlords-server/compare/v1.14.1...v1.14.2) (2020-09-24)


### Bug Fixes

* **google-oauth:** family_name is nullable ([99e5779](https://github.com/Nexters/landlords-server/commit/99e5779083dd2c5aa27a5aab6d1bdec78d8be2fc))