### PR TITLE
fix(oauth-email): 카카오 로그인 이메일 필수 수집 변경

### DIFF
--- a/src/apps/oauth/client.py
+++ b/src/apps/oauth/client.py
@@ -103,6 +103,7 @@ async def kakao_sign_in(
             "client_id": oauth_settings.KAKAO_REST_API_KEY,
             "redirect_uri": oauth_settings.KAKAO_AUTH_REDIRECT_URI,
             "code": request.query_params["code"],
+            "state": "nexters_17th_landlords",
             "client_secret": oauth_settings.KAKAO_CLIENT_SECRET,
         },
     )
@@ -112,7 +113,7 @@ async def kakao_sign_in(
     )
     user_info = UserInfo(
         sub="",
-        email="",
+        email=kakao_auth_info.kakao_account.email,
         name=kakao_auth_info.properties.nickname,
         picture=kakao_auth_info.properties.profile_image,
     )

--- a/src/apps/oauth/models/domain/kakao.py
+++ b/src/apps/oauth/models/domain/kakao.py
@@ -31,6 +31,9 @@ class KakaoAccount(BaseModel):
     has_gender: Optional[bool]
     gender_needs_agreement: Optional[bool]
     gender: Optional[str]
+    email: str
+    email_needs_agreement: Optional[bool]
+    has_email: Optional[bool]
 
     class Config:
         extra = Extra.allow


### PR DESCRIPTION
### [1.15.2](https://github.com/Nexters/landlords-server/compare/v1.15.1...v1.15.2) (2020-12-09)


### Bug Fixes

* **oauth-email:** 카카오 로그인 이메일 필수 수집 변경 ([847d4c2](https://github.com/Nexters/landlords-server/commit/847d4c2167d8b42802bad4c8e61d892254c81c84))